### PR TITLE
remove side effects on import

### DIFF
--- a/RomanNumeralConverter
+++ b/RomanNumeralConverter
@@ -72,35 +72,38 @@ def valid_entry_f(value):
     return True
 
 
+def main():
+    print("Welcome to the Roman Numeral Converter")
+    valid_entry = False 
+    while valid_entry == False:
+        value = input("Input a Roman Numeral or Number: \n")
+
+
+        # Checking Validity 
+        value = value.upper().strip().replace(" ", "")
+        valid_entry = valid_entry_f(value)
+
+        # Valid Input 
+        if valid_entry:
+            rom_num = value.isalpha()
+            if rom_num: 
+                conversion = rom_num_func(value)
+            else:
+                conversion = numerical(value)
+            print("Check the Results File")
+
+            # Writing in a New File
+            conversion = str(conversion)
+            with open ("Results.txt", "w") as f:
+                f.write("You inputted the value: " + value + "\n")
+                f.write("Your result was: " + conversion)
+                f.close()
+
+        # Invalid Input
+        else: 
+            print("Your Entry was Invalid. Try Again")
+
 # Main Method
+if __name__ == '__main__':
+    main()
 
-# if '__name__' == '__main__':
-print("Welcome to the Roman Numeral Converter")
-valid_entry = False 
-while valid_entry == False:
-    value = input("Input a Roman Numeral or Number: \n")
-
-
-    # Checking Validity 
-    value = value.upper().strip().replace(" ", "")
-    valid_entry = valid_entry_f(value)
-
-    # Valid Input 
-    if valid_entry:
-        rom_num = value.isalpha()
-        if rom_num: 
-            conversion = rom_num_func(value)
-        else:
-            conversion = numerical(value)
-        print("Check the Results File")
-
-        # Writing in a New File
-        conversion = str(conversion)
-        with open ("Results.txt", "w") as f:
-            f.write("You inputted the value: " + value + "\n")
-            f.write("Your result was: " + conversion)
-            f.close()
-
-    # Invalid Input
-    else: 
-        print("Your Entry was Invalid. Try Again")


### PR DESCRIPTION
When a script is imported it should make available its methods and variables to the importing script to use as it sees fit. When a script actually executes code on import it's unexpected and can even be dangerous. Python has a built-in variable named __name__ which is set to "__main__" if the script is called as an entry point by python, i.e. it's an application, vs a different value if it is imported, i.e. a library.