### PR TITLE
code cleanup: iterate from 1 to avoid zero-check clause

### DIFF
--- a/roman_numerals_lib.py
+++ b/roman_numerals_lib.py
@@ -63,29 +63,26 @@ def convert(value):
     if not value.isalpha():
         raise ValueError("This method can only convert a purely decimal or purely roman numeral to its counterpart.")
     # handle roman-to-decimal case, first validate, then convert
-    for i in range(len(value)):
+    for i in range(1, len(value)):
         if value[i] in dictionary.keys():
-            if i == 0:
-                continue
+            if len(value) - i >= 3:
+                if (value[i-1] == value[i]) & (value[i] == value[i+1]) & (value[i+1] == value[i+2]):
+                    raise ValueError("Invalid roman numeral: 4 or more letter repeats are not allowed.")
             else:
-                if len(value) - i >= 3:
-                    if (value[i-1] == value[i]) & (value[i] == value[i+1]) & (value[i+1] == value[i+2]):
-                        raise ValueError("Invalid roman numeral: 4 or more letter repeats are not allowed.")
+                if (dictionary.get(value[i-1]) * 10) < (dictionary.get(value[i])):
+                    raise ValueError("Invalid roman numeral: '{}{}' invalid prefix decrement / values not decreasing.".format(value[i-1], value[i]))
                 else:
-                    if (dictionary.get(value[i-1]) * 10) < (dictionary.get(value[i])):
-                        raise ValueError("Invalid roman numeral: '{}{}' invalid prefix decrement / values not decreasing.".format(value[i-1], value[i]))
+                    if (value[i-1] == value[i]) & ((value[i] == "V" )| (value[i] == "L") | (value[i] == "D")):
+                        raise ValueError("Invalid roman numeral: Repeating non-repeatable character {}.".format(value[i]))
                     else:
-                        if (value[i-1] == value[i]) & ((value[i] == "V" )| (value[i] == "L") | (value[i] == "D")):
-                            raise ValueError("Invalid roman numeral: Repeating non-repeatable character {}.".format(value[i]))
+                        if ((dictionary.get(value[i-1])) < dictionary.get(value[i])) & ((value[i-1] == "V") | (value[i-1] == "L") | (value[i-1] == "D")):
+                            raise ValueError("Invalid roman numeral: Cannot prefix-decrement with {} character.".format(value[i-1]))
                         else:
-                            if ((dictionary.get(value[i-1])) < dictionary.get(value[i])) & ((value[i-1] == "V") | (value[i-1] == "L") | (value[i-1] == "D")):
-                                raise ValueError("Invalid roman numeral: Cannot prefix-decrement with {} character.".format(value[i-1]))
+                            if i == len(value) - 1:
+                                continue
                             else:
-                                if i == len(value) - 1:
-                                    continue
-                                else:
-                                    if (dictionary.get(value[i-1]) == dictionary.get(value[i+1])) & (dictionary.get(value[i-1]) != dictionary.get(value[i])) & ((value[i-1] != "X") & (value[i-1] != "C") & (value[i-1] != "M")):
-                                        raise ValueError("Invalid roman numeral {}: Cannot prefix-decrement and suffix-increment, {} character is doing so.".format(value, value[i-1]))
+                                if (dictionary.get(value[i-1]) == dictionary.get(value[i+1])) & (dictionary.get(value[i-1]) != dictionary.get(value[i])) & ((value[i-1] != "X") & (value[i-1] != "C") & (value[i-1] != "M")):
+                                    raise ValueError("Invalid roman numeral {}: Cannot prefix-decrement and suffix-increment, {} character is doing so.".format(value, value[i-1]))
         else:
             raise ValueError("Roman numerals are only comprised of {} characters.".format(dictionary.keys()))
     return rom_num_func(value)


### PR DESCRIPTION
The real diff is to have the range() start from 1 and avoid the check for i == 0. The rest of the diffs are just from the following if/else statements being able to de-indent one tab.